### PR TITLE
Automatically reconnect on dropped connections.

### DIFF
--- a/src/firebird_fdw.c
+++ b/src/firebird_fdw.c
@@ -582,6 +582,9 @@ firebirdGetForeignPaths(PlannerInfo *root,
                                      fdw_state->total_cost,
                                      NIL,       /* no pathkeys */
                                      NULL,      /* no outer rel either */
+#if (PG_VERSION_NUM >= 90500)
+				     NULL,
+#endif
                                      NIL));     /* no fdw_private data */
 }
 
@@ -694,7 +697,9 @@ firebirdGetForeignPlan(PlannerInfo *root,
                             scan_relid,
                             NIL,    /* no expressions to evaluate */
                             fdw_private,
-							NIL /* no custom tlist */ );
+			    NIL /* no custom tlist */
+			    ,NIL, /* no recheck_quals */
+			    NULL); /* no outer_plan */
 #else
     return make_foreignscan(tlist,
                             local_exprs,


### PR DESCRIPTION
Store the connection parameters in ConnCacheEntry so we can reconnect when the connection fails, and reconnect automatically.
