### PR TITLE
Update convert.c – PostgreSQL does not allow BIGINT with decimal point

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -426,7 +426,7 @@ generateColumnMetadataQuery(StringInfoData *data_type_sql, char *fb_table_name)
 "			   CASE f.rdb$field_sub_type \n"
 "				 WHEN 1 THEN 'NUMERIC(' || f.rdb$field_precision || ',' || (-f.rdb$field_scale) || ')' \n"
 "				 WHEN 2 THEN 'DECIMAL(' || f.rdb$field_precision || ',' || (-f.rdb$field_scale) || ')' \n"
-"				 ELSE 'BIGINT' \n"
+"                ELSE CASE WHEN f.rdb$field_scale < 0 THEN 'DECIMAL' ELSE 'BIGINT' END \n"
 "			   END \n"
 "			 WHEN 8	  THEN \n"
 "			   CASE f.rdb$field_sub_type \n"


### PR DESCRIPTION
When there is a Firebird BIGINT column having a negative scale, firebird_fdw's outputs a BIGINT column type definition during IMPORT SCHEMA, but then formats values with a decimal point, which PostgreSQL does not accept for BIGINT columns. So SELECTing data from such columns currently fails.

This patch changes firebird_fdw to output a DECIMAL column type definition for BIGINT Firebird columns having a negative scale.